### PR TITLE
Creation of serializers and addition of Tax and Contact models

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -5,7 +5,7 @@ from django.db import models
 class User(models.Model):
     username = models.CharField(max_length=30, unique=True)
     email = models.EmailField(max_length=75, unique=True)
-    password = models.CharField()
+    password = models.CharField(max_length=100)
     is_vendor = models.BooleanField(default=False)
     is_admin = models.BooleanField(default=True)
 
@@ -14,7 +14,7 @@ class User(models.Model):
     
 # Vendor model
 class Vendor(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='users')
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='vendor')
     bio = models.TextField()
     shipping_details = models.TextField()
     return_policy = models.TextField()
@@ -33,8 +33,8 @@ class Category(models.Model):
         return self.name
 
 class Product(models.Model):
-    vendor = models.ForeignKey(Vendor, on_delete=models.CASCADE, related_name='vendor')
-    category = models.ForeignKey(Category, on_delete=models.CASCADE, related_name='category')
+    vendor = models.ForeignKey(Vendor, on_delete=models.CASCADE, related_name='products')
+    category = models.ForeignKey(Category, on_delete=models.CASCADE, related_name='products')
     slug = models.SlugField(unique=True)
     price = models.FloatField() # If there is an error regarding prices, change this to DecimalField
     stock = models.PositiveIntegerField(default=1)
@@ -48,7 +48,7 @@ class Product(models.Model):
         return self.name
     
 class Order(models.Model):
-    customer = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user')
+    customer = models.ForeignKey(User, on_delete=models.CASCADE, related_name='order')
     products = models.ManyToManyField(Product, through='OrderItem')
     total_price = models.FloatField()
     shipping_address = models.TextField()
@@ -59,24 +59,24 @@ class Order(models.Model):
         return self.total_price
     
 class OrderItem(models.Model):
-    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='order')
-    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='product')
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='items')
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
     quantity = models.PositiveIntegerField(default=1)
 
 class Cart(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user')
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='cart')
     session_id = models.CharField(max_length=50, null=True, blank=True)
     items = models.ManyToManyField(Product, through='CartItem')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now= True)
 
 class CartItem(models.Model):
-    cart = models.ForeignKey(Cart, on_delete=models.CASCADE, related_name='cart')
-    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='products')
+    cart = models.ForeignKey(Cart, on_delete=models.CASCADE, related_name='cart_items')
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
     quantity = models.PositiveIntegerField(default=1)
 
 class Shipping(models.Model):
-    name = models.CharField()
+    name = models.CharField(max_length=75)
     description = models.TextField()
     rating = models.FloatField()
 
@@ -84,10 +84,10 @@ class Shipping(models.Model):
         return self.name
     
 class Payment(models.Model):
-    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='order')
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='payment')
     method = models.CharField(max_length=50)
     amount = models.FloatField()
-    transaction_id = models.CharField()
+    transaction_id = models.CharField(max_length=50)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -103,8 +103,8 @@ class Coupon(models.Model): # For discounts in shop.
         return self.code
     
 class Review(models.Model):
-    customer = models.ForeignKey(User, on_delete=models.CASCADE, related_name='customer')
-    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='product')
+    customer = models.ForeignKey(User, on_delete=models.CASCADE, related_name='review')
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='review')
     rating = models.PositiveIntegerField()
     comment = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
@@ -113,12 +113,12 @@ class Review(models.Model):
         return self.comment
     
 class Wishlist(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user')
-    products = models.ManyToManyField(Product, related_name='products')
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='wishlist')
+    products = models.ManyToManyField(Product, related_name='wishlist')
 
 
 class Notification(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user')
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='notification')
     message = models.TextField()
     sent_at = models.DateTimeField(auto_now_add=True)
 
@@ -126,7 +126,7 @@ class Notification(models.Model):
         return self.sent_at
     
 class Blog(models.Model):
-    author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='user')
+    author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='blog_post')
     slug = models.SlugField(unique=True)
     title = models.TextField()
     content = models.TextField()
@@ -146,7 +146,7 @@ class Contact(models.Model):
 class Analytics(models.Model):
     sales = models.DecimalField(max_digits=10, decimal_places=2)
     traffic = models.PositiveIntegerField()
-    popular_products = models.ManyToManyField(Product, related_name='popular-products')
+    popular_products = models.ManyToManyField(Product, related_name='analytics')
     created_at = models.DateTimeField()
 
 # Site Configuration model

--- a/core/models.py
+++ b/core/models.py
@@ -141,7 +141,11 @@ class FAQ(models.Model):
         return self.question
     
 class Contact(models.Model):
-    pass
+    name = models.CharField(max_length=100)
+    email = models.EmailField(max_length=75)
+    telephone = models.CharField(max_length=20)
+    message = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
 
 class Analytics(models.Model):
     sales = models.DecimalField(max_digits=10, decimal_places=2)
@@ -171,4 +175,13 @@ class Refund(models.Model):
 
     def __str__(self):
         return self.reason
+    
+class Tax(models.Model):
+    name = models.CharField(max_length=75)
+    rate = models.DecimalField(max_digits=5, decimal_places=2)
+    country = models.CharField(max_length=75)
+    state = models.CharField(max_length=75)
+
+    def __str__(self):
+        return self.name
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -1,0 +1,30 @@
+# To hold the serializers for our models
+from rest_framework import serializers
+from .models import (User, Vendor, Product, Order, Category, Cart, CartItem, OrderItem, Payment, Analytics, FAQ, Shipping, Coupon, Refund, Review, Blog, Configuration, Contact, Wishlist, Subscription)
+
+# User serializer
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'
+
+class VendorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Vendor
+        fields = '__all__'
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = '__all__'
+
+class ProductSerializer(serializers.ModelSerializer):
+    category = CategorySerializer(read_only=True)
+    vendor = VendorSerializer(read_only=True)
+    reviews = serializers.StringRelatedField(many=True, read_only=True)
+    
+    class Meta:
+        model = Product
+        fields = '__all__'
+
+

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -1,8 +1,7 @@
 # To hold the serializers for our models
 from rest_framework import serializers
-from .models import (User, Vendor, Product, Order, Category, Cart, CartItem, OrderItem, Payment, Analytics, FAQ, Shipping, Coupon, Refund, Review, Blog, Configuration, Contact, Wishlist, Subscription)
+from .models import (User, Vendor, Product, Order, Category, Cart, CartItem, OrderItem, Payment, Analytics, FAQ, Shipping, Coupon, Refund, Review, Blog, Configuration, Contact, Wishlist, Subscription, Notification)
 
-# User serializer
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
@@ -27,4 +26,107 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = '__all__'
 
+class OrderSerializer(serializers.ModelSerializer):
+    customer = UserSerializer(read_only=True)
+    products = ProductSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Order
+        fields = '__all__'
+
+class OrderItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OrderItem
+        fields = '__all__'
+
+class CartSerializer(serializers.ModelSerializer):
+    #user = UserSerializer(read_only=True)
+    items = ProductSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Cart
+        fields = '__all__'
+
+class CartItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CartItem
+        fields = '__all__'
+
+class PaymentSerializer(serializers.ModelSerializer):
+    order = OrderSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Payment
+        fields = '__all__'
+
+class ShippingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Shipping
+        fields = '__all__'
+
+class CouponSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Coupon
+        fields = '__all__'
+
+class WishlistSerializer(serializers.ModelSerializer):
+    products = ProductSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Wishlist
+        fields = '__all__'
+
+
+class ReviewSerializer(serializers.ModelSerializer):
+    customer = UserSerializer(read_only=True)
+
+    class Meta:
+        model = Review
+        fields = '__all__'
+
+class NotificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notification
+        fields = '__all__'   
+
+class FAQSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FAQ
+        fields = '__all__'   
+
+class BlogSerializer(serializers.ModelSerializer):
+    author = UserSerializer(read_only=True)
+
+    class Meta:
+        model = Blog
+        fields = '__all__'
+
+class ContactSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Contact
+        fields = '__all__'
+
+class AnalyticsSerializer(serializers.ModelSerializer):
+    popular_products = ProductSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Analytics
+        fields = '__all__'
+
+class ConfigurationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Configuration
+        fields = '__all__'
+
+class RefundSerializer(serializers.ModelSerializer):
+    order = OrderSerializer(read_only=True)
+
+    class Meta:
+        model = Refund
+        fields = '__all__'
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Subscription
+        fields = '__all__' 
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'core',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
# Creation of serializers and addition of *Tax* and *Contact* models
**1. Creation of serializers**
What's a serializer? In the context of Django REST Framework (DRF), a serializer is a component that is used to transform complex data types, such as Django models or querysets, into native Python data types. These native data types can then be easily rendered into JSON, XML, or other content types suitable for APIs. Conversely, serializers can also transform parsed data back into complex types, after validating the input.

Serializers for different models have been created to be able to parse the data into JSON format, for example,
```python

from rest_framework import serializers
from .models import User, Review

# A user serializer
class UserSerializer(serializers.ModelSerializer):
    class Meta:
        model = User
        fields = '__all__'

# A product serializer
class ReviewSerializer(serializers.ModelSerializer):
    user = UserSerializer(read_only=True)
    class Meta:
        model = Review
        fields = '__all__'


```
For the ReviewSerializer, there is a *user* variable. This user variable extends the UserSerializer to be shown on the ReviewSerializer as read only, meaning that you cannot deserialize it.

**2. Addition of the *Tax* and *Contact* models**:
Check core/models.py for more information. 
