### PR TITLE
Change: Change in Vendor model

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -21,7 +21,7 @@ class Vendor(models.Model):
     bank_details = models.TextField()
 
     def __str__(self):
-        return self.bio
+        return self.user.username
     
 # Category model
 class Category(models.Model):


### PR DESCRIPTION
Changed the string reprsentation in the Vendor model from ```vendor.bio``` to ```vendor.user.username``` to return a Vendor's username instead of their bio for better identification as the bio is not unique to a vendor.

```python

class Vendor(models.Model):
    ...
    def __str__(self):
        return self.user.username

```